### PR TITLE
update gmail.md to add warning about ratelimits

### DIFF
--- a/_providers/gmail.md
+++ b/_providers/gmail.md
@@ -17,7 +17,7 @@ server:
 opt:
   delete_to_trash: true
 before_login_hint: |
-  For Gmail accounts, you need to have "2-Step Verification" enabled and create an app-password.
+  For Gmail accounts, you need to have "2-Step Verification" enabled and create an app-password. Gmail also has a 500 correspondents limit per day (if you have a group chat with 100 users, sending 5 message is enough to reach the limit.)
 last_checked: 2024-08
 website: https://gmail.com
 ---


### PR DESCRIPTION
gmail has a 500 correspondants limit per day, after which it stops sending messages to people, this should be alerted to users before they try to use their gmail account with DC, while there is a link to an article about the rate limits, i think most users, don't click on it, so it should be more explicit and in the face of the users how much the limit it

idk why i made pr message this long lmao